### PR TITLE
Allow use include directive in rst file

### DIFF
--- a/rst2wp.py
+++ b/rst2wp.py
@@ -441,7 +441,9 @@ class Rst2Wp(Application):
         if not self.dont_check_tags and not self.preview:
             validity.Validity.verify_categories(wp, categories)
 
+        # Source path is for use include directive in rst file
         output = core.publish_parts(source=text, writer=writer,
+                                    source_path=os.path.abspath(self.filename),
                                     reader=reader,
                                     settings_overrides={
                 'wordpress_instance' : wp,


### PR DESCRIPTION
All rst can include file, use relative path is ok.

Good include file works more better than known_hosts config file.
