### PR TITLE
Fixed configuration initialization

### DIFF
--- a/rst2wp.py
+++ b/rst2wp.py
@@ -146,8 +146,8 @@ class Application(object):
             config.set('config', 'save_uploads', 'no')
             config.set('config', 'scale_images', 'no')
             config.set('config', 'default_category', 'Uncategorized')
-            config.set('config', 'tab_width', 4)
-            config.set('config', 'initial_header_level', 2)
+            config.set('config', 'tab_width', '4')
+            config.set('config', 'initial_header_level', '2')
 
             path = os.path.join(BaseDirectory.save_config_path('rst2wp'), 'wordpressrc')
             print 'Need configuration! Edit %s'%(path,)


### PR DESCRIPTION
Hello,
In Ubuntu 12.04 upon running the script for the first time, I got:

```
Traceback (most recent call last):
  File "./rst2wp", line 588, in <module>
    Rst2Wp().run()
  File "./rst2wp", line 405, in run
    config = self.config
  File "./rst2wp", line 116, in config
    return self._load_config()
  File "./rst2wp", line 149, in _load_config
    config.set('config', 'tab_width', 4)
  File "/usr/lib/python2.7/ConfigParser.py", line 743, in set
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```

So I just fixed it by quoting the number options and it now works for me.

Thanks for the tool.
