### PR TITLE
Port to Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Requirements
 * python-magic
 * `python-pyxdg <https://www.freedesktop.org/wiki/Software/pyxdg/>`_ (not to be confused with `xdg <https://pypi.org/project/xdg/>`_)
 * pillow
+* You probably also want ``exiftran`` from `fbida <https://www.kraxel.org/blog/linux/fbida/>`_
 
 Features
 ========

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,10 @@ their entire site to something else.
 Requirements
 ============
 
-* python-argparse
 * python-docutils
 * python-magic
-* python-xdg
+* `python-pyxdg <https://www.freedesktop.org/wiki/Software/pyxdg/>`_ (not to be confused with `xdg <https://pypi.org/project/xdg/>`_)
+* pillow
 
 Features
 ========

--- a/rst2wp.py
+++ b/rst2wp.py
@@ -1,1 +1,0 @@
-rst2wp/rst2wp.py

--- a/rst2wp/__main__.py
+++ b/rst2wp/__main__.py
@@ -1,0 +1,4 @@
+from .rst2wp import main
+
+if __name__ == '__main__':
+    main()

--- a/rst2wp/directive.py
+++ b/rst2wp/directive.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os.path
 
-import urllib
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 from docutils.parsers.rst import Directive
 from .config import POSTS_LOCATION, IMAGES_LOCATION, TEMP_DIRECTORY, TEMP_FILES
 
@@ -46,16 +46,16 @@ class DownloadDirective(Directive):
         filename = os.path.join(dir, target_filename)
         if not os.path.exists(filename):
             print("Downloading {0}".format(uri.encode('utf-8')))
-            filename, headers = urllib.urlretrieve(uri.encode('utf-8'), os.path.join(dir, target_filename))
+            filename, headers = urllib.request.urlretrieve(uri.encode('utf-8'), os.path.join(dir, target_filename))
 
         self.cleanup_file(filename)
         return filename
 
     def uri_filename(self, uri):
-        tuple = urlparse.urlparse(uri)
+        tuple = urllib.parse.urlparse(uri)
         path = tuple.path
         target_filename = path.split('/')[-1]
         if '.' not in target_filename:
-            target_filename = raw_input("Image specified by %s doesn't have a filename.\nWhat would you like this image to be named?\n> "%(uri,))
+            target_filename = input("Image specified by %s doesn't have a filename.\nWhat would you like this image to be named?\n> "%(uri,))
 
-        return urllib.unquote(target_filename)
+        return urllib.parse.unquote(target_filename)

--- a/rst2wp/directive.py
+++ b/rst2wp/directive.py
@@ -45,8 +45,8 @@ class DownloadDirective(Directive):
 
         filename = os.path.join(dir, target_filename)
         if not os.path.exists(filename):
-            print("Downloading {0}".format(uri.encode('utf-8')))
-            filename, headers = urllib.request.urlretrieve(uri.encode('utf-8'), os.path.join(dir, target_filename))
+            print("Downloading {0}".format(uri))
+            filename, headers = urllib.request.urlretrieve(uri, os.path.join(dir, target_filename))
 
         self.cleanup_file(filename)
         return filename

--- a/rst2wp/directive.py
+++ b/rst2wp/directive.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os.path
 
 import urllib
 import urlparse
 from docutils.parsers.rst import Directive
-from config import POSTS_LOCATION, IMAGES_LOCATION, TEMP_DIRECTORY, TEMP_FILES
+from .config import POSTS_LOCATION, IMAGES_LOCATION, TEMP_DIRECTORY, TEMP_FILES
 
 
 class DownloadDirective(Directive):

--- a/rst2wp/lib/wordpresslib.py
+++ b/rst2wp/lib/wordpresslib.py
@@ -48,6 +48,7 @@
         * http://www.sixapart.com/movabletype/docs/mtmanual_programmatic.html
         * http://docs.python.org/lib/module-xmlrpclib.html
 """
+from __future__ import print_function
 
 __author__ = "Michele Ferretti <black.bird@tiscali.it>"
 __copyright__ = "Copyright (c) 2005 Michele Ferretti"
@@ -241,7 +242,7 @@ def wordpress_call(func):
     def call(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except xmlrpclib.Fault, fault:
+        except xmlrpclib.Fault as fault:
             raise WordPressException(fault)
 
     return call
@@ -269,7 +270,7 @@ class WordPressClient():
         postObj.excerpt         = post['mt_excerpt']
         postObj.user            = post['userid']
         postObj.date            = time.strptime(str(post['date_created_gmt']), "%Y%m%dT%H:%M:%S")
-        print "Parsing date:", postObj.date, post['dateCreated']
+        print("Parsing date:", postObj.date, post['dateCreated'])
         postObj.link            = post['link']
         postObj.textMore        = post['mt_text_more']
         postObj.allowComments   = post['mt_allow_comments'] == 1
@@ -411,7 +412,7 @@ class WordPressClient():
         if post.date:
             # Convert date to UTC
             blogContent['date_created_gmt'] = xmlrpclib.DateTime(time.gmtime(time.mktime(post.date)))
-            print "Back-converting dateCreated:", post.date, blogContent['date_created_gmt']
+            print("Back-converting dateCreated:", post.date, blogContent['date_created_gmt'])
 
         # Get remote method: e.g. self._server.metaWeblog.editPost
         ns = getattr(self._server, namespace)
@@ -424,7 +425,7 @@ class WordPressClient():
     def _marshal_categories_ids(self, categories):
         for c in categories:
             if c.id == -1:
-                raise TypeError, "bad mojo -- categories need IDs"
+                raise TypeError("bad mojo -- categories need IDs")
         return [{'categoryId': cat.id} for cat in categories]
 
     def _marshal_tags_names(self, tags):

--- a/rst2wp/lib/wordpresslib.py
+++ b/rst2wp/lib/wordpresslib.py
@@ -54,7 +54,6 @@ __author__ = "Michele Ferretti <black.bird@tiscali.it>"
 __copyright__ = "Copyright (c) 2005 Michele Ferretti"
 __license__ = "LGPL"
 
-import exceptions
 import re
 import os
 import xmlrpc.client
@@ -64,7 +63,7 @@ from functools import wraps
 import mimetypes
 import warnings
 
-class WordPressException(exceptions.Exception):
+class WordPressException(Exception):
     """Custom exception for WordPress client operations
     """
     def __init__(self, obj):

--- a/rst2wp/lib/wordpresslib.py
+++ b/rst2wp/lib/wordpresslib.py
@@ -609,7 +609,7 @@ class WordPressClient(object):
 
     @wordpress_call
     def __upload_file(self, mediaFileName, **fields):
-        f = file(mediaFileName, 'rb')
+        f = open(mediaFileName, 'rb')
         mediaBits = f.read()
         f.close()
 

--- a/rst2wp/lib/wordpresslib.py
+++ b/rst2wp/lib/wordpresslib.py
@@ -57,7 +57,7 @@ __license__ = "LGPL"
 import exceptions
 import re
 import os
-import xmlrpclib
+import xmlrpc.client
 import datetime
 import time
 from functools import wraps
@@ -68,7 +68,7 @@ class WordPressException(exceptions.Exception):
     """Custom exception for WordPress client operations
     """
     def __init__(self, obj):
-        if isinstance(obj, xmlrpclib.Fault):
+        if isinstance(obj, xmlrpc.client.Fault):
             self.id = obj.faultCode
             self.message = obj.faultString
         else:
@@ -99,7 +99,7 @@ class WordPressException(exceptions.Exception):
 #
 # http://www.simmonsconsulting.com/2008/02/29/daylight-saving-time-and-wordpress-xmlrpc/
 
-class WordPressBlog():
+class WordPressBlog(object):
     """Represents blog item
     """
     def __init__(self, id=None, name=None, url=None, isAdmin=None):
@@ -118,7 +118,7 @@ class WordPressBlog():
             )
 
 
-class WordPressUser():
+class WordPressUser(object):
     """Represents user item
     """
     def __init__(self, id=None, firstname=None, lastname=None, nickname=None,
@@ -214,7 +214,7 @@ class WordPressCategory(CategoryBase):
 
         return data
 
-class WordPressPost():
+class WordPressPost(object):
     """Represents post item
     """
     def __init__(self, id=None, title=None, date=None, permaLink=None,
@@ -242,12 +242,12 @@ def wordpress_call(func):
     def call(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except xmlrpclib.Fault as fault:
+        except xmlrpc.client.Fault as fault:
             raise WordPressException(fault)
 
     return call
 
-class WordPressClient():
+class WordPressClient(object):
     """Client for connect to WordPress XML-RPC interface
     """
 
@@ -258,7 +258,7 @@ class WordPressClient():
         self.blogId = 0
         self.categories = None
         self.tags = None
-        self._server = xmlrpclib.ServerProxy(self.url)
+        self._server = xmlrpc.client.ServerProxy(self.url)
 
     def _filterPost(self, post):
         """Transform post struct in WordPressPost instance
@@ -411,7 +411,7 @@ class WordPressClient():
 
         if post.date:
             # Convert date to UTC
-            blogContent['date_created_gmt'] = xmlrpclib.DateTime(time.gmtime(time.mktime(post.date)))
+            blogContent['date_created_gmt'] = xmlrpc.client.DateTime(time.gmtime(time.mktime(post.date)))
             print("Back-converting dateCreated:", post.date, blogContent['date_created_gmt'])
 
         # Get remote method: e.g. self._server.metaWeblog.editPost
@@ -616,7 +616,7 @@ class WordPressClient():
 
         mediaStruct = {
             'name' : os.path.basename(mediaFileName),
-            'bits' : xmlrpclib.Binary(mediaBits)
+            'bits' : xmlrpc.client.Binary(mediaBits)
         }
 
         mediaStruct.update(fields)

--- a/rst2wp/lib/wordpresslib.py
+++ b/rst2wp/lib/wordpresslib.py
@@ -625,4 +625,3 @@ class WordPressClient(object):
         result = self._server.metaWeblog.newMediaObject(self.blogId,
                                 self.user, self.password, mediaStruct)
         return result['url']
-

--- a/rst2wp/my_image.py
+++ b/rst2wp/my_image.py
@@ -113,7 +113,7 @@ class MyImageDirective(directives.images.Image, DownloadDirective):
 
     def process_parameters(self):
         '''Store all the uploaded forms for this directive with canonical names in document.settings'''
-        for key, value in self.options.items():
+        for key, value in list(self.options.items()):
             if key == 'saved_as': key = 'uploaded'
             if key.startswith('form-'): key = key.replace('form-', 'uploaded-scale')
             if key.startswith('uploaded'):

--- a/rst2wp/my_image.py
+++ b/rst2wp/my_image.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 ## MyImageDirective: a replacement for the Image directive that
 ## insinuates transforms when necessary.
 import subprocess
@@ -9,7 +11,7 @@ from docutils.parsers.rst import roles, directives, languages
 import os.path
 
 from PIL import Image
-from directive import DownloadDirective
+from .directive import DownloadDirective
 
 # Arguments starting with form-* are all OK.
 # Simple dictionary that accepts all those options.
@@ -170,7 +172,7 @@ class MyImageDirective(directives.images.Image, DownloadDirective):
                 factor = float(scale)
                 dimensions = image.size
                 dimensions = int(dimensions[0]*factor), int(dimensions[1]*factor)
-            except ValueError, e:
+            except ValueError as e:
                 dimensions = scale.split('x')
                 dimensions = int(dimensions[0]), int(dimensions[1])
 

--- a/rst2wp/nodes.py
+++ b/rst2wp/nodes.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 #Strategy here: monkeypatch some docutils node classes, specifically
 #field_list and field, so that we can
 
 import docutils.nodes
-import utils, validity
+from . import utils, validity
 
 old_field_list = docutils.nodes.field_list
 
@@ -47,8 +48,8 @@ class rst2wp_field_list(old_field_list):
         elif isinstance(data, docutils.nodes.paragraph):
             value = data.children[0].astext()
         else:
-            raise TypeError, "don't know how to handle a %s in the header %s"%(
-                data.__class__, key)
+            raise TypeError("don't know how to handle a %s in the header %s"%(
+                data.__class__, key))
 
         return key, value
 

--- a/rst2wp/rst2wp.py
+++ b/rst2wp/rst2wp.py
@@ -344,7 +344,7 @@ class Rst2Wp(Application):
 
         Replaces an existing field of the same name.'''
         keystring = ':{key}:'.format(key=key)
-        new_line = '{keystring} {value}'.format(keystring=keystring, value=value.encode('utf8'))
+        new_line = '{keystring} {value}'.format(keystring=keystring, value=value)
 
         # Add field after other fields, or replace if exists
         in_fields = False
@@ -370,14 +370,14 @@ class Rst2Wp(Application):
 
     def replace_directive(self, document, directive, uri, key, value):
         '''Add a field to a URL-based directive.'''
-        r = re.compile('{name}::\s+({uri})'.format(name=directive, uri = re.escape(uri.encode('utf-8'))))
+        r = re.compile('{name}::\s+({uri})'.format(name=directive, uri = re.escape(uri)))
         lines = self.text.split('\n')
 
         for i in range(len(lines)):
             if r.search(lines[i]):
                 n = self.get_indent(lines[i])
                 # FIXME: check if it's already there
-                lines.insert(i+1, ((n+3)*' ')+':{key}: {value}'.format(key=key, value=value.encode('utf-8')))
+                lines.insert(i+1, ((n+3)*' ')+':{key}: {value}'.format(key=key, value=value))
 
         self.text = '\n'.join(lines)
 

--- a/rst2wp/rst2wp.py
+++ b/rst2wp/rst2wp.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import re
 import argparse
 from xdg import BaseDirectory
-import ConfigParser
+import configparser
 import sys
 import os.path
 import tempfile, subprocess, time, datetime
@@ -128,7 +128,7 @@ class Application(object):
             print('config loaded')
 
     def _load_config(self):
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.ConfigParser()
         self.VERBOSE = False
 
         self._read_configs_into(config)
@@ -172,7 +172,7 @@ class Application(object):
             filename = os.path.join(dir, configfile)
             if not os.path.exists(filename): continue
 
-            config = ConfigParser.SafeConfigParser()
+            config = configparser.ConfigParser()
             with file(filename) as f:
                 config.readfp(f)
             if not config.has_section(section): continue
@@ -186,7 +186,7 @@ class Application(object):
 
 class Rst2Wp(Application):
     def _known_link_stanza(self):
-        known_links = ConfigParser.SafeConfigParser()
+        known_links = configparser.ConfigParser()
         self._read_configs_into(known_links, 'known_links', 'known links')
 
         links = []
@@ -234,7 +234,7 @@ class Rst2Wp(Application):
         if isinstance(self.alt_config, str): self.config_name = self.alt_config
 
     def prompt(self, msg):
-        return raw_input(msg)
+        return input(msg)
 
     def save_post_info(self, document, key, value):
         data_storage = self.data_storage
@@ -262,7 +262,7 @@ class Rst2Wp(Application):
 
     def _save_config_info(self, section, key, value, location=None):
         location = location or POSTS_LOCATION
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.ConfigParser()
         filename = location()
         if os.path.exists(filename):
             with file(filename) as f:
@@ -333,7 +333,7 @@ class Rst2Wp(Application):
         return self._has_config_info(document, directive + ' ' + url, key, location=IMAGES_LOCATION)
 
     def _has_config_info(self, document, section, key, location=POSTS_LOCATION):
-        class NO_DEFAULT:
+        class NO_DEFAULT(object):
             pass
 
         return self.search_configs(location(), section, key, NO_DEFAULT) is not NO_DEFAULT
@@ -490,7 +490,7 @@ class Rst2Wp(Application):
         body = utils.replace_newlines(body)
 
         new_post_data = {
-            'title' : unicode(fields['title']),
+            'title' : str(fields['title']),
             'categories': categories,
             'tags': tags,
             'description': body,
@@ -499,7 +499,7 @@ class Rst2Wp(Application):
         if self.has_post_info(reader.document, 'id'):
             new_post = False
             post_id = self.get_post_info(reader.document, 'id')
-            post_id = unicode(post_id)
+            post_id = str(post_id)
             post = wp.get_post(post_id)
         else:
             new_post = True

--- a/rst2wp/rst2wp.py
+++ b/rst2wp/rst2wp.py
@@ -123,7 +123,7 @@ class Application(object):
             filename = os.path.join(dir, filepath)
             if not os.path.exists(filename): continue
             print("loading {0} from".format(config_name), filename)
-            with file(filename) as f:
+            with open(filename) as f:
                 config.readfp(f)
             print('config loaded')
 
@@ -153,7 +153,7 @@ class Application(object):
 
             path = os.path.join(BaseDirectory.save_config_path('rst2wp'), 'wordpressrc')
             print('Need configuration! Edit %s'%(path,))
-            with file(path, 'wb') as fp:
+            with open(path, 'wb') as fp:
                 config.write(fp)
             sys.exit()
 
@@ -173,7 +173,7 @@ class Application(object):
             if not os.path.exists(filename): continue
 
             config = configparser.ConfigParser()
-            with file(filename) as f:
+            with open(filename) as f:
                 config.readfp(f)
             if not config.has_section(section): continue
 
@@ -265,21 +265,21 @@ class Rst2Wp(Application):
         config = configparser.ConfigParser()
         filename = location()
         if os.path.exists(filename):
-            with file(filename) as f:
+            with open(filename) as f:
                 config.readfp(f)
 
         if not config.has_section(section):
             config.add_section(section)
 
         config.set(section, key, value)
-        with file(filename, 'wb') as fp:
+        with open(filename, 'wb') as fp:
             config.write(fp)
 
     def _save_post_updated(self):
         # Save immediately, so as to not forget the location of an uploaded image
         if self.should_save_file():
             print("Saving file with new data")
-            file(self.filename, 'w').write(self.text)
+            open(self.filename, 'w').write(self.text)
 
     def get_post_info(self, document, key):
         '''Get stored information about a post.
@@ -384,7 +384,7 @@ class Rst2Wp(Application):
     def should_save_file(self):
         data_storage = self.config.get('config', 'data_storage')
         save_to_file = data_storage in ['both', 'file']
-        return self.text != file(self.filename).read() and save_to_file
+        return self.text != open(self.filename).read() and save_to_file
 
     def create_client(self, url, username, password):
         wp = wordpresslib.WordPressClient(url, username, password)
@@ -428,7 +428,7 @@ class Rst2Wp(Application):
             elif self.list_categories:
                 return self.run_list_categories()
 
-        with file(self.filename) as f:
+        with open(self.filename) as f:
             self.text = text = f.read()
 
         # self.text is the version we eventually save;

--- a/rst2wp/rst2wp.py
+++ b/rst2wp/rst2wp.py
@@ -26,7 +26,7 @@ import docutils.transforms
 #import yaml
 from . import utils
 
-sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "rst2wp/lib"))
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "lib"))
 
 import wordpresslib
 from . import my_image # registers MyImageDirective

--- a/rst2wp/upload.py
+++ b/rst2wp/upload.py
@@ -1,13 +1,15 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import mimetypes
 import docutils.parsers.rst.directives
 from docutils import core, io, nodes
 from docutils.parsers.rst import roles, directives, languages
-from config import IMAGES_LOCATION
+from .config import IMAGES_LOCATION
 import magic  # needed to guess file types
-from directive import DownloadDirective
+from .directive import DownloadDirective
 
-import utils
+from . import utils
 
 class UploadDirective(DownloadDirective):
     required_arguments = 1

--- a/rst2wp/upload.py
+++ b/rst2wp/upload.py
@@ -56,7 +56,7 @@ class UploadDirective(DownloadDirective):
 
     def upload_file(self, filename):
         if not self.state_machine.document.settings.wordpress_instance: return filename
-        print("Uploading {0}".format(filename.encode('utf-8')))
+        print("Uploading {0}".format(filename))
         self.wp = self.state_machine.document.settings.wordpress_instance
         return self.wp.upload_file(filename)
 
@@ -66,7 +66,7 @@ class UploadDirective(DownloadDirective):
     def guess_type(self, filename):
         m = magic.open(magic.MAGIC_NONE)
         m.load()
-        type = m.file(filename.encode('utf-8'))
+        type = m.file(filename)
         m.close()
         #print filename, type
         return type

--- a/rst2wp/validity.py
+++ b/rst2wp/validity.py
@@ -3,7 +3,6 @@
 Encapsulates logic for whether to check existence of tags/categories,
 and how to check it based on a document.'''
 from __future__ import print_function
-raw_input = __builtins__['raw_input']
 
 class Validity(object):
     @classmethod

--- a/rst2wp/validity.py
+++ b/rst2wp/validity.py
@@ -5,7 +5,7 @@ and how to check it based on a document.'''
 from __future__ import print_function
 raw_input = __builtins__['raw_input']
 
-class Validity():
+class Validity(object):
     @classmethod
     def should_check(cls, document):
         # Check if there is a wordpress_instance, and there is either
@@ -59,8 +59,8 @@ WordPress will break tags at commas. If you really want a tag with a comma, add 
     @classmethod
     def read_base(cls, name):
         fmt = {'name': repr(str(name))}
-        slug = raw_input("Slug for {name} [auto-generate]: ".format(**fmt))
-        description = raw_input("Description for {name} [none]: ".format(**fmt))
+        slug = input("Slug for {name} [auto-generate]: ".format(**fmt))
+        description = input("Description for {name} [none]: ".format(**fmt))
         return {'slug': slug, 'description': description, 'name': name}
 
     @classmethod
@@ -73,16 +73,16 @@ If you really want a tag with a comma in the name, create it via the web interfa
 
         print("Post has non-existent tag {tag}. Ctrl-C to cancel.".format(**fmt))
         print("rst2wp can create the tag automatically, but can't set description or slug via XML-RPC API. If you want to edit these things, log in to the blog!")
-        raw_input("Confirm creation? [yes] ")
+        input("Confirm creation? [yes] ")
 
     @classmethod
     def read_category(cls, wp, cat):
         fmt = {'category': repr(str(cat))}
         print("Post has non-existent category {category}. Ctrl-C to cancel.".format(**fmt))
-        raw_input("Confirm? [yes]")
+        input("Confirm? [yes]")
 
         data = cls.read_base(cat)
-        parent_id = raw_input("Parent id for {category} [none]: ".format(**fmt))
+        parent_id = input("Parent id for {category} [none]: ".format(**fmt))
 
         c = wordpresslib.WordPressCategory(parent_id=parent_id, **data)
         wp.new_category(c)

--- a/rst2wp/validity.py
+++ b/rst2wp/validity.py
@@ -2,6 +2,7 @@
 
 Encapsulates logic for whether to check existence of tags/categories,
 and how to check it based on a document.'''
+from __future__ import print_function
 raw_input = __builtins__['raw_input']
 
 class Validity():
@@ -44,9 +45,9 @@ class Validity():
     @classmethod
     def check_existing_tag(cls, wp, tag):
         if ',' in tag:
-            raise ValueError, """Cannot use tags with ',' in the name.
+            raise ValueError("""Cannot use tags with ',' in the name.
 
-WordPress will break tags at commas. If you really want a tag with a comma, add it via the web interface."""
+WordPress will break tags at commas. If you really want a tag with a comma, add it via the web interface.""")
         if not wp.has_tag(tag):
             tag = cls.read_tag(tag)
 
@@ -66,18 +67,18 @@ WordPress will break tags at commas. If you really want a tag with a comma, add 
     def read_tag(cls, tag):
         fmt = {'tag': repr(str(tag))}
         if ',' in tag:
-            raise ValueError, """Cannot create tag with ',' in the name.
+            raise ValueError("""Cannot create tag with ',' in the name.
 
-If you really want a tag with a comma in the name, create it via the web interface first."""
+If you really want a tag with a comma in the name, create it via the web interface first.""")
 
-        print "Post has non-existent tag {tag}. Ctrl-C to cancel.".format(**fmt)
-        print "rst2wp can create the tag automatically, but can't set description or slug via XML-RPC API. If you want to edit these things, log in to the blog!"
+        print("Post has non-existent tag {tag}. Ctrl-C to cancel.".format(**fmt))
+        print("rst2wp can create the tag automatically, but can't set description or slug via XML-RPC API. If you want to edit these things, log in to the blog!")
         raw_input("Confirm creation? [yes] ")
 
     @classmethod
     def read_category(cls, wp, cat):
         fmt = {'category': repr(str(cat))}
-        print "Post has non-existent category {category}. Ctrl-C to cancel.".format(**fmt)
+        print("Post has non-existent category {category}. Ctrl-C to cancel.".format(**fmt))
         raw_input("Confirm? [yes]")
 
         data = cls.read_base(cat)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -2,9 +2,9 @@
 import re
 import os
 import xml.etree.cElementTree
-import Image
-import mock
-import wordpresslib
+from PIL import Image
+from unittest import mock
+from rst2wp.lib import wordpresslib
 try:
     import unittest2 as unittest
 except ImportError:
@@ -12,9 +12,9 @@ except ImportError:
 
 from docutils import core
 
-import nodes
-import my_image
-import rst2wp
+from rst2wp import nodes
+from rst2wp import my_image
+from rst2wp import rst2wp
 
 class TestImage(unittest.TestCase):
     def find_images(self, output):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -151,8 +151,8 @@ class TestImage(unittest.TestCase):
         self.match_image(images[0], {'reference': 'http://foo-90/on/you', 'src': 'http://foo-rot90-scale0.25/on/you'})
 
 
-    @mock.patch('Image.open')
-    @mock.patch('urllib.urlretrieve')
+    @mock.patch('PIL.Image.open')
+    @mock.patch('urllib.request.urlretrieve')
     @mock.patch('os.mkdir')
     @mock.patch('os.path.exists')
     def test_rotate(self, os_path_exists, os_mkdir, urlretrieve, image_open):
@@ -185,8 +185,8 @@ class TestImage(unittest.TestCase):
         self.assertEqual(len(images), 1)
         self.match_image(images[0], {'reference': None, 'src': 'http://wordpress/foo-rot90.jpg'})
 
-    @mock.patch('Image.open')
-    @mock.patch('urllib.urlretrieve')
+    @mock.patch('PIL.Image.open')
+    @mock.patch('urllib.request.urlretrieve')
     @mock.patch('os.mkdir')
     @mock.patch('os.path.exists')
     def test_rotate_and_scale(self, os_path_exists, os_mkdir, urlretrieve, image_open):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -54,11 +54,12 @@ class TestImage(unittest.TestCase):
         wp.upload_file.side_effect = lambda filename, overwrite=True: "http://wordpress/"+os.path.basename(filename)
 
         directive_uris = {'image': {}}
-        output = core.publish_parts(source=text, writer_name='html4css1',
-                                    settings_overrides = {'bibliographic_fields': {},
-                                                          'application': application,
-                                                          'directive_uris': directive_uris,
-                                                          'wordpress_instance': wp})
+        with mock.patch('subprocess.check_call') as check_call:
+            output = core.publish_parts(source=text, writer_name='html4css1',
+                                        settings_overrides = {'bibliographic_fields': {},
+                                                              'application': application,
+                                                              'directive_uris': directive_uris,
+                                                              'wordpress_instance': wp})
         return {'output': output['whole'], 'directive_uris': directive_uris,
                 'application': application, 'wordpress_instance': wp}
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -38,7 +38,7 @@ class TestImage(unittest.TestCase):
     def match_image(self, image, spec):
         for x in spec:
             if image[x] != spec[x]:
-                raise AssertionError, "Image {0} did not match spec {1}".format(image, spec)
+                raise AssertionError("Image {0} did not match spec {1}".format(image, spec))
 
     def mock_run(self, text):
         application = mock.Mock(rst2wp.Rst2Wp)
@@ -205,7 +205,7 @@ class TestImage(unittest.TestCase):
         images[1].size = (4000, 3000)
         images_iter = iter(images)
 
-        image_open.side_effect = lambda filename: images_iter.next()
+        image_open.side_effect = lambda filename: next(images_iter)
 
         output = self.mock_run(text)
         html = output['output']

--- a/tests/test_rstparser.py
+++ b/tests/test_rstparser.py
@@ -31,7 +31,7 @@ This is a test."""
         self.assertEqual(fields['tags'], ['tag1', 'tag2'])
         self.assertEqual(fields['categories'], ['default_category'])
 
-    @mock.patch('validity.raw_input')
+    @mock.patch('rst2wp.validity.input')
     def test_validity(self, raw_input):
         text = '''
 :tags: - tag1
@@ -53,7 +53,7 @@ This is a test.'''
         wordpress_instance.has_tag.asssert_called_with("tag2")
         assert raw_input.called
 
-    @mock.patch('validity.raw_input')
+    @mock.patch('rst2wp.validity.input')
     def test_validity_existing(self, raw_input):
         text = '''
 :tags: - tag1

--- a/tests/test_rstparser.py
+++ b/tests/test_rstparser.py
@@ -1,6 +1,6 @@
-import nodes
-import mock
-import wordpresslib
+from rst2wp import nodes
+from unittest import mock
+from rst2wp.lib import wordpresslib
 try:
     import unittest2 as unittest
 except ImportError:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -10,19 +10,33 @@ class TestUpload(unittest.TestCase):
         self.state_machine = mock.Mock()
         self.up = upload.UploadDirective('upload', [filename], {}, None, 'lineno', 'content_offset', '.. upload::', 'state', self.state_machine)
 
+    def mock_run(self):
+        def fake_os_stat(filename):
+            m = mock.Mock()
+            m.st_size = 1337
+            return m
+
+        with mock.patch('os.path.exists') as os_path_exists:
+            with mock.patch('os.stat') as os_stat:
+                with mock.patch('magic.open') as magic_open:
+                    os_path_exists.side_effect = lambda filename: filename.endswith('file.odf')
+                    os_stat.side_effect = fake_os_stat
+                    magic_open().file.side_effect = 'text/plain'
+                    return self.up.run()
+
     def test_upload(self):
         self.create_directive('/path/to/file.odf')
         self.assertEqual(self.up.arguments, ['/path/to/file.odf'])
 
-        output = self.up.run()
+        output = self.mock_run()
 
         assert self.state_machine.document.settings.wordpress_instance.upload_file.called
         self.assertEqual(self.state_machine.document.settings.wordpress_instance.upload_file.call_args_list,
-                         [(('/path/to/file.odf',), {})])
+                         [mock.call('/tmp/file.odf')])
 
     def test_no_upload(self):
         self.create_directive('/path/to/file.odf')
         self.up.options['uploaded'] = 'http://example.com/already/exists'
 
-        output = self.up.run()
+        output = self.mock_run()
         self.assertFalse(self.state_machine.document.settings.wordpress_instance.upload_file.called)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,5 @@
-import upload
-import mock
+from rst2wp import upload
+from unittest import mock
 try:
     import unittest2 as unittest
 except ImportError:


### PR DESCRIPTION
This is a rough-and-ready port to Python 3 (specifically I tested this with Python 3.8.5) to address #15. I used `futurize` to do most of it and then tested it out on one of the blogs I maintain using rst2wp. I didn't upload a new post but I did make some edits to an old post, and `--list-tags` works fine.
